### PR TITLE
allow fractional sizes in minimap

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -60,15 +60,15 @@ class Main
       default: true
       description: 'If this option is enabled and Soft Wrap is checked then the Minimap max width is set to the Preferred Line Length value.'
     charWidth:
-      type: 'integer'
+      type: 'number'
       default: 1
-      minimum: 1
+      minimum: .5
     charHeight:
-      type: 'integer'
+      type: 'number'
       default: 2
-      minimum: 1
+      minimum: .5
     interline:
-      type: 'integer'
+      type: 'number'
       default: 1
       minimum: 0
       description: 'The space between lines in the minimap in pixels.'


### PR DESCRIPTION
Hi, 
I have a "retina" screen mac and wanted to make use of the smaller real pixels; currently I have 1 real pixel interline, 3 real pixels char height, and 2 real pixels char width. I also experimented with smaller sizes, but my poor eyesight disagreed. 
Anyway, to do that, I needed the character sizes to be fractional – with a devicePixelRatio of 2, I want to use increments of .5. Hence my patch, and hence this pull request.
